### PR TITLE
Wrapped Message and MobileDevice in the SmsSpec namespace.

### DIFF
--- a/lib/sms_spec/drivers/twilio-ruby.rb
+++ b/lib/sms_spec/drivers/twilio-ruby.rb
@@ -10,7 +10,7 @@ class Twilio::REST::Client
     def create(opts={})
       to = opts[:to]
       body = opts[:body]
-      add_message Message.new(:number => to, :body => body)
+      add_message SmsSpec::Message.new(:number => to, :body => body)
     end
   end
 

--- a/lib/sms_spec/message.rb
+++ b/lib/sms_spec/message.rb
@@ -1,11 +1,13 @@
-class Message
-  attr_accessor :number
-  attr_accessor :body
+module SmsSpec
+  class Message
+    attr_accessor :number
+    attr_accessor :body
 
-  include SmsSpec::Util
+    include SmsSpec::Util
 
-  def initialize(opts={})
-    @number = sanitize opts[:number]
-    @body = opts[:body]
+    def initialize(opts={})
+      @number = sanitize opts[:number]
+      @body = opts[:body]
+    end
   end
 end

--- a/lib/sms_spec/mobile_device.rb
+++ b/lib/sms_spec/mobile_device.rb
@@ -1,10 +1,12 @@
-class MobileDevice
+module SmsSpec
+  class MobileDevice
 
-  def initialize(number)
-    @number = number
-  end
+    def initialize(number)
+      @number = number
+    end
 
-  def messages
-    SmsSpec::Data.messages.select {|d| d.number == @number}
+    def messages
+      SmsSpec::Data.messages.select {|d| d.number == @number}
+    end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -17,7 +17,7 @@ describe SmsSpec::Helpers do
     describe "after a message has been sent" do
       it "adds a message" do
         lambda {
-          add_message Message.new :number => "5555555512", :body => "Hello there"
+          add_message SmsSpec::Message.new :number => "5555555512", :body => "Hello there"
         }.should change(messages, :count).by(1)
       end
     end
@@ -40,9 +40,9 @@ describe SmsSpec::Helpers do
 
   describe ".clear_sms_messages" do
     it "removes all messages" do
-      add_message Message.new :number => "5555555512", :body => "Hello there"
-      add_message Message.new :number => "5555555512", :body => "Hello there"
-      add_message Message.new :number => "5555555512", :body => "Hello there"
+      add_message SmsSpec::Message.new :number => "5555555512", :body => "Hello there"
+      add_message SmsSpec::Message.new :number => "5555555512", :body => "Hello there"
+      add_message SmsSpec::Message.new :number => "5555555512", :body => "Hello there"
 
       messages.should have(3).messages
     end
@@ -60,8 +60,8 @@ describe SmsSpec::Helpers do
     end
 
     describe "when there are messages" do
-      let(:message1) { Message.new :number => "5555555513", :body => "Hi" }
-      let(:message2) { Message.new :number => "5555555512", :body => "Hello there" }
+      let(:message1) { SmsSpec::Message.new :number => "5555555513", :body => "Hi" }
+      let(:message2) { SmsSpec::Message.new :number => "5555555512", :body => "Hello there" }
 
       before do
         add_message message1

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -42,16 +42,16 @@ describe SmsSpec::Matchers do
 
     describe "when the mobile device has no text messages" do
       it "should not match" do
-        device = MobileDevice.new(:number => mobile_number)
+        device = SmsSpec::MobileDevice.new(:number => mobile_number)
         have_text_messages.should_not match(device)
       end
     end
 
     describe "when the mobile device has text messages" do
       it "should match" do
-        add_message Message.new(:number => mobile_number, :body => "something")
+        add_message SmsSpec::Message.new(:number => mobile_number, :body => "something")
 
-        device = MobileDevice.new(mobile_number)
+        device = SmsSpec::MobileDevice.new(mobile_number)
         have_text_messages.should match(device)
       end
     end
@@ -60,7 +60,7 @@ describe SmsSpec::Matchers do
   describe ".have_body" do
     describe "when bodies match" do
       it "matches" do
-        message = Message.new(:number => mobile_number, :body => "something")
+        message = SmsSpec::Message.new(:number => mobile_number, :body => "something")
 
         have_body("something").should match(message)
       end


### PR DESCRIPTION
We are using this gem in our tests. We also have a model called Message. We ran into a superclass conflict, and fixed by wrapping Message and MobileDevice in the SmsSpec namespace.

Here's what our error looked like:
`superclass mismatch for class Message (TypeError)`

I updated the tests and all pass on my machine.
