### PR TITLE
Fixed running matchers_spec.rb individually

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,8 @@ An RSpec DSL and Cucumber steps to test SMS interactions with your
 Ruby on Rails application.
 
 Currently this gem only supports testing SMS messageing using the
-[twilio-ruby](https://github.com/twilio/twilio-ruby) gem.
+[twilio-ruby](https://github.com/twilio/twilio-ruby) and
+[lookout-clickatell](https://github.com/lookout/clickatell) gem.
 
 ##Setup
 Add the sms-spec gem to your Gemfile:

--- a/lib/sms_spec/drivers/twilio-ruby.rb
+++ b/lib/sms_spec/drivers/twilio-ruby.rb
@@ -10,7 +10,8 @@ class Twilio::REST::Client
     def create(opts={})
       to = opts[:to]
       body = opts[:body]
-      add_message SmsSpec::Message.new(:number => to, :body => body)
+      from = opts[:from]
+      add_message SmsSpec::Message.new(:number => to, :from => from, :body => body)
     end
   end
 

--- a/lib/sms_spec/helpers.rb
+++ b/lib/sms_spec/helpers.rb
@@ -33,6 +33,13 @@ module SmsSpec
         "From"=> from,
         "FromZip"=>"49507"
       }
+    end
+
+    def clkatel_message(from, text, opts={})
+      base_options = {
+        "From"=> from,
+        "Text" => text
+      }
 
       base_options.merge! opts
     end

--- a/lib/sms_spec/message.rb
+++ b/lib/sms_spec/message.rb
@@ -2,12 +2,14 @@ module SmsSpec
   class Message
     attr_accessor :number
     attr_accessor :body
+    attr_accessor :from
 
     include SmsSpec::Util
 
     def initialize(opts={})
       @number = sanitize opts[:number]
       @body = opts[:body]
+      @from = opts[:from]
     end
   end
 end

--- a/sms-spec.gemspec
+++ b/sms-spec.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "twilio-ruby"
+  s.add_development_dependency "lookout-clickatell"
   s.add_development_dependency "guard-rspec"
   s.add_development_dependency "pry"
   s.add_development_dependency "rb-fsevent"

--- a/spec/drivers_clickatell_spec.rb
+++ b/spec/drivers_clickatell_spec.rb
@@ -5,66 +5,43 @@ require File.join(File.dirname(__FILE__), *%w[spec_helper])
 describe SmsSpec do
   include SmsSpec::Helpers
 
+  before do
+    # Got TEST NUMBER FROM: http://forums.clickatell.com/clickatell/
+    #    topics/clickatell_sandbox_similar_to_paypal_sandbox
+    @to_number   = '27999900001' # TEST NUMBER
+    @from_number = '27999900005' # TEST NUMBER
+    @api = Clickatell::API.authenticate(
+      ENV["CLICKATELL_API_KEY"],
+      ENV["CLICKATELL_LOGIN"],
+      ENV["CLICKATELL_PASSWORD"]
+    )
+  end
+
   before :each do
     SmsSpec::Data.clear_messages
   end
 
   describe "the clickatell driver" do
-    it "is assignable" 
-#FIXME
-#do
-#      SmsSpec.driver = :"clickatell"
-#    end
 
     it "intercepts calls to clickatell's sms client" do
-      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-      auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
-
-#FIXME
-#      @client = Twilio::REST::Client.new account_sid, auth_token
-#      @client.account.sms.messages.create(
-#        :from => '+14159341234',
-#        :to => '+16105557069',
-#        :body => 'Hey there!'
-#      )
-#
-#      open_last_text_message_for("+16105557069")
-#      current_text_message.should_not be_nil
+      expect { 
+        @api.send_message(@to_number, 'Hello from clickatell')
+      }.to raise_error("No Credit Left")
     end
 
     it "allows for sid method calls on the account object" do
-      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-      auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
-
-#FIXME
-#      @client = Twilio::REST::Client.new account_sid, auth_token
-#      @client.account.sms.messages.create(
-#        :from => '+14159341234',
-#        :to => '+16105557069',
-#        :body => 'Hey there!'
-#      )
-#
-#      open_last_text_message_for("+16105557069")
-#      current_text_message.should_not be_nil
-#      @client.account.should respond_to(:sid)
-#      @client.account.sid.should be(account_sid)
+      expect { 
+        @api.send_message(@to_number, 'Hello from clickatell')
+      }.to raise_error("No Credit Left")
     end
 
-    it "records the from number for a message" do
-      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-      auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
-
-#FIXME
-#      @client = Twilio::REST::Client.new account_sid, auth_token
-#      @client.account.sms.messages.create(
-#        :from => '+14159341234',
-#        :to => '+16105557069',
-#        :body => 'Hey there!'
-#      )
-#
-#      open_last_text_message_for("+16105557069")
-#      current_text_message.from.should eq('+14159341234')
+    it "records the 'from' number for a message" do
+      additional_opts = { from: @from_number }
+      expect { 
+        @api.send_message(@to_number, 'Hello from clickatell', additional_opts)
+      }.to raise_error("No Credit Left")
     end
 
   end
 end
+

--- a/spec/drivers_clickatell_spec.rb
+++ b/spec/drivers_clickatell_spec.rb
@@ -1,0 +1,70 @@
+require 'clickatell'
+require 'twilio-ruby'
+require File.join(File.dirname(__FILE__), *%w[spec_helper])
+
+describe SmsSpec do
+  include SmsSpec::Helpers
+
+  before :each do
+    SmsSpec::Data.clear_messages
+  end
+
+  describe "the clickatell driver" do
+    it "is assignable" 
+#FIXME
+#do
+#      SmsSpec.driver = :"clickatell"
+#    end
+
+    it "intercepts calls to clickatell's sms client" do
+      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
+
+#FIXME
+#      @client = Twilio::REST::Client.new account_sid, auth_token
+#      @client.account.sms.messages.create(
+#        :from => '+14159341234',
+#        :to => '+16105557069',
+#        :body => 'Hey there!'
+#      )
+#
+#      open_last_text_message_for("+16105557069")
+#      current_text_message.should_not be_nil
+    end
+
+    it "allows for sid method calls on the account object" do
+      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
+
+#FIXME
+#      @client = Twilio::REST::Client.new account_sid, auth_token
+#      @client.account.sms.messages.create(
+#        :from => '+14159341234',
+#        :to => '+16105557069',
+#        :body => 'Hey there!'
+#      )
+#
+#      open_last_text_message_for("+16105557069")
+#      current_text_message.should_not be_nil
+#      @client.account.should respond_to(:sid)
+#      @client.account.sid.should be(account_sid)
+    end
+
+    it "records the from number for a message" do
+      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
+
+#FIXME
+#      @client = Twilio::REST::Client.new account_sid, auth_token
+#      @client.account.sms.messages.create(
+#        :from => '+14159341234',
+#        :to => '+16105557069',
+#        :body => 'Hey there!'
+#      )
+#
+#      open_last_text_message_for("+16105557069")
+#      current_text_message.from.should eq('+14159341234')
+    end
+
+  end
+end

--- a/spec/drivers_spec.rb
+++ b/spec/drivers_spec.rb
@@ -45,5 +45,20 @@ describe SmsSpec do
       @client.account.sid.should be(account_sid)
     end
 
+    it "records the from number for a message" do
+      account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
+
+      @client = Twilio::REST::Client.new account_sid, auth_token
+      @client.account.sms.messages.create(
+        :from => '+14159341234',
+        :to => '+16105557069',
+        :body => 'Hey there!'
+      )
+
+      open_last_text_message_for("+16105557069")
+      current_text_message.from.should eq('+14159341234')
+    end
+
   end
 end

--- a/spec/drivers_spec.rb
+++ b/spec/drivers_spec.rb
@@ -61,4 +61,5 @@ describe SmsSpec do
     end
 
   end
+
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -121,4 +121,31 @@ describe SmsSpec::Helpers do
     end
   end
 
+  describe ".clkatel_message" do
+    context "with defaults" do
+      let(:message) {
+        clkatel_message("+16165559982", "Ahoy!")
+      }
+
+      it "modifies the From attribute" do
+        message["From"].should eql("+16165559982")
+      end
+
+      it "Modifies the Body attribute" do
+        message["Text"].should eql("Ahoy!")
+      end
+    end
+
+    describe "Overriding options" do
+      let(:message) {
+        clkatel_message("+16165559982", "Ahoy!")
+      }
+
+      it "overrides the specified attributes" do
+        message["Text"].should eql("Ahoy!")
+        message["From"].should eql("+16165559982")
+      end
+    end
+  end
+
 end

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -1,4 +1,5 @@
 require 'twilio-ruby'
+require 'clickatell'
 require File.join(File.dirname(__FILE__), *%w[spec_helper])
 
 describe SmsSpec::Matchers do

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -1,3 +1,4 @@
+require 'twilio-ruby'
 require File.join(File.dirname(__FILE__), *%w[spec_helper])
 
 describe SmsSpec::Matchers do


### PR DESCRIPTION
Fixed running matchers_spec.rb individually
- By adding **require 'twilio-ruby** line to matchers_spec.rb file.
